### PR TITLE
Update 06-escaping_characters.md

### DIFF
--- a/src/03-html/06-escaping_characters.md
+++ b/src/03-html/06-escaping_characters.md
@@ -177,7 +177,7 @@ ghci> :load Html.hs
 [1 of 1] Compiling Html    ( Html.hs, interpreted )
 Ok, one module loaded.
 ghci> render (html_ "<title>" (p_ "<body>"))
-"<html><head><title>&lt;title&gt;</title></head><body><p>&lt;body&gt;</p></body></html>"
+"<html><head><title><title></title><body><p><body</p></body></head></html>"
 ```
 
 As well as import library modules:


### PR DESCRIPTION
Fixed output from the render function to not have escaped characters